### PR TITLE
Assign A/B test group by test name & login/email.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,11 @@
 *.rbc
 .bundle
 .config
+.vagrant
 .yardoc
 Gemfile.lock
 InstalledFiles
+Vagrantfile
 _yardoc
 coverage
 doc/

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ Or install it yourself as:
 
 ## Usage
 
-Kissable enables you to conduct a/b tests contingent on users having cookies enabled. To conduct a test you need to have a name for a test and specify how many groups you want and the ratios of these groups.
+Kissable helps you run A/B tests by breaking up your users into test groups (e.g. Original vs. Variant). Name your test, list your test groups, and the ratio at which people should be distributed to each group. Kissable does the assignment pseudo-randomly.
+
+For anonymous users cookies must be enabled. Cookies are used to assign a user to a group and keep him there. For logged in users a unique identifier (e.g. login) is used instead for the same purpose.
 
 You instantiate the object with these items.
 
@@ -54,6 +56,14 @@ end
   ab_test = Kissable::AB.new('top-navigation test')
   users_ab_group = ab_test.group(cookies)
   ab_test.tracking_script(users_ab_group)
+```
+
+* For logged in users, you can use some unique identifier instead.
+
+```ruby
+  ab_test = Kissable::AB.new('top-navigation test')
+  users_ab_group = ab_test.group(email)
+  # Add your custom tracking code here.
 ```
 
 ### Rails

--- a/lib/kissable/ab.rb
+++ b/lib/kissable/ab.rb
@@ -19,19 +19,13 @@ module Kissable
       validate_ratios
     end
 
-    def group(cookies)
-      @cookies = cookies
+    # Assigns a test group based on the 'abid' cookie or login (email).
+    # Takes either a cookies object (Hash-like) or login (String).
+    def group(object)
+      (object.is_a? String) ? (@login = object) : (@cookies = object)
 
       abset.each do |i, val|
         return i if val > seed
-      end
-    end
-
-    def group_by_login(login)
-      @login = login
-
-      abset.each do |i, val|
-        return i if val > seed_by_login
       end
     end
 
@@ -54,11 +48,10 @@ module Kissable
     end
 
     def seed
-      @seed ||= (sha ^ ab_cookie_value) % 100
-    end
+      return @seed if @seed
 
-    def seed_by_login
-      @seed ||= (sha ^ login_sha) % 100
+      xor = @login ? login_sha : ab_cookie_value
+      @seed = (sha ^ xor) % 100
     end
 
     def login_sha

--- a/lib/kissable/ab.rb
+++ b/lib/kissable/ab.rb
@@ -4,7 +4,7 @@ module Kissable
   class AB
     MAX_GROUP_COUNT = 4
 
-    attr_reader :groups, :ratios, :test_name
+    attr_reader :groups, :login, :ratios, :test_name
 
     def initialize(test_name, groups=nil, ratios=nil)
       @test_name = test_name
@@ -24,6 +24,14 @@ module Kissable
 
       abset.each do |i, val|
         return i if val > seed
+      end
+    end
+
+    def group_by_login(login)
+      @login = login
+
+      abset.each do |i, val|
+        return i if val > seed_by_login
       end
     end
 
@@ -47,6 +55,14 @@ module Kissable
 
     def seed
       @seed ||= (sha ^ ab_cookie_value) % 100
+    end
+
+    def seed_by_login
+      @seed ||= (sha ^ login_sha) % 100
+    end
+
+    def login_sha
+      @login_sha = Digest::SHA1.hexdigest(login).to_i(16)
     end
 
     def abset

--- a/lib/kissable/version.rb
+++ b/lib/kissable/version.rb
@@ -1,3 +1,3 @@
 module Kissable
-  VERSION = "1.0.0a1"
+  VERSION = "1.0.1"
 end

--- a/spec/kissable/ab_spec.rb
+++ b/spec/kissable/ab_spec.rb
@@ -5,6 +5,7 @@ describe Kissable::AB do
   let(:groups) { nil }
   let(:ratios) { nil }
   let(:cookies) { {} }
+  let(:login) { "jsmith@example.com" }
   let(:ab_test) { described_class.new(test_name, groups, ratios) }
 
   describe '#initialize' do
@@ -63,67 +64,84 @@ describe Kissable::AB do
   end
 
   describe '#group' do
-    let(:group) { ab_test.group(cookies) }
+    context "when using cookies to group" do
+      let(:group) { ab_test.group(cookies) }
 
-    it "is returns Original or Variant" do
-      expect(group).to match(/Original|Variant/)
-    end
-
-    context "when cookie exists" do
-      before :each do
-        ab_test.stub(:cookies).and_return('abid' => 1)
+      it "is returns Original or Variant" do
+        expect(group).to match(/Original|Variant/)
       end
 
-      it "doesn't change the cookie" do
-        expect { group }.to_not change { ab_test.cookies }
+      context "when cookie exists" do
+        before :each do
+          ab_test.stub(:cookies).and_return('abid' => 1)
+        end
+
+        it "doesn't change the cookie" do
+          expect { group }.to_not change { ab_test.cookies }
+        end
       end
-    end
 
-    context "when cookie doesn't exist" do
-      it "sets a cookie" do
-        expect { group }.to change { ab_test.cookies }.from({})
-      end
+      context "when cookie doesn't exist" do
+        it "sets a cookie" do
+          expect { group }.to change { ab_test.cookies }.from({})
+        end
 
-      describe "the cookie" do
-        let(:cookie) { ab_test.cookies['abid'] }
+        describe "the cookie" do
+          let(:cookie) { ab_test.cookies['abid'] }
 
-        context "when the domain has been configured" do
-          let(:domain) { 'someaweseomedomain.com' }
+          context "when the domain has been configured" do
+            let(:domain) { 'someaweseomedomain.com' }
 
-          it "has the domain key set to the correct value" do
-            Kissable.configure do |config|
-              config.domain = domain
+            it "has the domain key set to the correct value" do
+              Kissable.configure do |config|
+                config.domain = domain
+              end
+
+              group
+              expect(cookie).to include(:domain => domain)
             end
+          end
 
+          context "when the domain hasn't been configured" do
+            it "doesn't include a domain key" do
+              Kissable.configure do |config|
+                config.domain = nil
+              end
+
+              group
+              expect(cookie).to_not include(:domain)
+            end
+          end
+
+          it "expires" do
             group
-            expect(cookie).to include(:domain => domain)
+            expect(cookie).to include(:expires)
+          end
+
+          it "has a path" do
+            group
+            expect(cookie).to include(:path => "/")
+          end
+
+          it "contains a value" do
+            group
+            expect(cookie).to include(:value)
           end
         end
+      end
+    end
 
-        context "when the domain hasn't been configured" do
-          it "doesn't include a domain key" do
-            Kissable.configure do |config|
-              config.domain = nil
-            end
+    context "when using login to group" do
+      let(:group) { ab_test.group(login) }
 
-            group
-            expect(cookie).to_not include(:domain)
-          end
-        end
+      it "returns Original or Variant" do
+        expect(group).to match(/Original|Variant/)
+      end
 
-        it "expires" do
-          group
-          expect(cookie).to include(:expires)
-        end
-
-        it "has a path" do
-          group
-          expect(cookie).to include(:path => "/")
-        end
-
-        it "contains a value" do
-          group
-          expect(cookie).to include(:value)
+      it "returns the same group for an email" do
+        10.times do
+          test_copy = described_class.new(test_name)
+          expect(test_copy.group(login)).to eq(group)
         end
       end
     end

--- a/spec/kissable/ab_spec.rb
+++ b/spec/kissable/ab_spec.rb
@@ -5,7 +5,7 @@ describe Kissable::AB do
   let(:groups) { nil }
   let(:ratios) { nil }
   let(:cookies) { {} }
-  let(:login) { "jsmith@example.com" }
+  let(:login) { 'jsmith@example.com' }
   let(:ab_test) { described_class.new(test_name, groups, ratios) }
 
   describe '#initialize' do
@@ -64,10 +64,10 @@ describe Kissable::AB do
   end
 
   describe '#group' do
-    context "when using cookies to group" do
+    context "when using cookies" do
       let(:group) { ab_test.group(cookies) }
 
-      it "is returns Original or Variant" do
+      it "returns Original or Variant" do
         expect(group).to match(/Original|Variant/)
       end
 
@@ -131,14 +131,14 @@ describe Kissable::AB do
       end
     end
 
-    context "when using login to group" do
+    context "when using login" do
       let(:group) { ab_test.group(login) }
 
       it "returns Original or Variant" do
         expect(group).to match(/Original|Variant/)
       end
 
-      it "returns the same group for an email" do
+      it "always returns the same group" do
         10.times do
           test_copy = described_class.new(test_name)
           expect(test_copy.group(login)).to eq(group)


### PR DESCRIPTION
@bhardin @mattysads 

Instead of trying passing in either a cookies object or login string to the group method, I think it's clearer/safer to have a separate method.

group_by_login always returns the same group for a given test name and login/email. For the same test name, this distributes pretty evenly across test groups for different emails.
